### PR TITLE
Fix orphaned temp files with memmap option.

### DIFF
--- a/spalipy/__init__.py
+++ b/spalipy/__init__.py
@@ -1,3 +1,3 @@
 from .spalipy import Spalipy  # noqa
 
-__version__ = "3.5.2"
+__version__ = "3.5.3"

--- a/spalipy/spalipy.py
+++ b/spalipy/spalipy.py
@@ -222,7 +222,7 @@ class Spalipy:
         Additionally, create output np.ndarrays as np.memmap temporary files.
         See `tempfile` documentation for default temp directory search
         configurations.
-    temp_file : str or Path, optional (default=None)
+    temp_dir : str or Path, optional (default=None)
         explicit temporary file write location for `use_memmap` functionality.
         If None, environment variables TMPDIR,TEMP,TMP will be checked before
         defaulting to platform-specific temp file locations (e.g. /tmp).

--- a/spalipy/utils.py
+++ b/spalipy/utils.py
@@ -36,11 +36,13 @@ def _memmap_tryfree(obj: Any) -> bool:
 def _memmap_create_temp(
     ndarray_to_save: np.ndarray, temp_dir: Union[Path, str, None] = None
 ) -> np.memmap:
-    """Create and return temporary file np.memmap object using defaults as per tempfile.
-    Temp file will not have a visible entry in the filesystem, will persist until the file descriptor is closed.
-    Storage path is temp_dir, or if None environment variables TMPDIR, TEMP or TMP will be used,
-    else if these or not set see Python `tempfile` documentation for platform-specific
-    default locations. This is typically /tmp for Linux.
+    """
+    Create and return temporary file np.memmap object using defaults as per tempfile.
+    Temp file will not have a visible entry in the filesystem, but the file will
+    persist until the file descriptor is closed.
+    Storage path is temp_dir, or if None environment variables TMPDIR, TEMP or TMP
+    will be used, else if these or not set see Python `tempfile` documentation for
+    platform-specific default locations. This is typically /tmp for Linux.
     """
     if not isinstance(ndarray_to_save, np.ndarray):
         raise ValueError("ndarray_to_save must be np.ndarray object.")

--- a/spalipy/utils.py
+++ b/spalipy/utils.py
@@ -33,7 +33,9 @@ def _memmap_tryfree(obj: Any) -> bool:
     return False
 
 
-def _memmap_create_temp(ndarray_to_save: np.ndarray, temp_dir: Union[Path, str, None] = None) -> np.memmap:
+def _memmap_create_temp(
+    ndarray_to_save: np.ndarray, temp_dir: Union[Path, str, None] = None
+) -> np.memmap:
     """Create and return temporary file np.memmap object using defaults as per tempfile.
     Temp file will not have a visible entry in the filesystem, will persist until the file descriptor is closed.
     Storage path is temp_dir, or if None environment variables TMPDIR, TEMP or TMP will be used,


### PR DESCRIPTION
Certain code execution environments and/or process termination methods do not allow for `tempfile.NamedTemporaryFile` to assure the `delete=True` option is completed, resulting in orphaned temporary files on the filesystem.

Use `tempfile.TemporaryFile` instead, which either does not create a directory listing or unlinks the file immediately after creation, as part of the temporary file creation request. The file will exist until the process closes or releases the file descriptor, but it will not be listed on the filesystem. See `tempfile` documentation for an authoritative description.

Also, add optional parameter for temporary directory at Spalipy init, instead of requiring environment setting (`TMPDIR` etc.), or resorting to platform default.